### PR TITLE
#168050005 Blacklist tokens appropriately

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,8 @@ services:
    ports:
      - '${DB_DOCKER_PORT}:5432'
 
-   redis:
-    image: redis
-
+ redis:
+   image: redis
    environment:         
       - POSTGRES_DB= ${DB_NAME}
       - POSTGRES_USER= ${DB_USER}
@@ -31,6 +30,6 @@ services:
       - DB_PASS= ${DB_PASS}
       - JWT_SECRET= ${JWT_SECRET}
       - SENDGRID_API_KEY= ${SENDGRID_API_KEY}
-      - REDIS_URL = redis://redis:6379
+      - REDIS_URL=redis://redis:6379
 volumes:
   pgdata:

--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -67,6 +67,8 @@ class UserController {
     const { email, password } = req.body;
     const searchUser = await findUserByEmail(email);
     if (!searchUser) return res.status(401).json({ status: 401, error: 'Invalid user credentials' });
+    const isVerified = searchUser.is_verified;
+    if (!isVerified) return res.status(401).json({ status: 401, error: 'Email verification required' });
     const comparePass = comparePassword(password, searchUser.password);
     if (!comparePass) return res.status(404).json({ status: 404, error: 'Invalid user credentials' });
     const {
@@ -87,8 +89,7 @@ class UserController {
   static async logoutUser(req, res) {
     const { email } = req.user;
     try {
-      redisClient.set(email, req.token, () => {
-      });
+      redisClient.set(email, req.token);
       response.setSuccess(200, 'You have logged out');
       return response.send(res);
     } catch (error) {

--- a/test/User.spec.js
+++ b/test/User.spec.js
@@ -131,7 +131,7 @@ describe('users endpoints', () => {
 
   describe('POST: /api/v1/auth/login', () => {
     let userData;
-    it('Should not login an unregistered user', () => {
+    it('Should not login an unregistered user', (done) => {
       userData = {
         email: 'new@mail.com',
         password: 'Anyp4ss'
@@ -143,10 +143,11 @@ describe('users endpoints', () => {
         .end((err, res) => {
           expect(res.status).to.equal(401);
           expect(res.body.error).to.equal('Invalid user credentials');
+          done();
         });
     });
 
-    it('Should not login a user with an invalid password', () => {
+    it('Should not login a user with an invalid password', (done) => {
       userData = {
         email: dummyUser.email,
         password: 'wrongPass'
@@ -158,6 +159,7 @@ describe('users endpoints', () => {
         .end((err, res) => {
           expect(res.status).to.equal(401);
           expect(res.body.error).to.equal('Invalid user credentials');
+          done();
         });
     });
 


### PR DESCRIPTION
#### What does this PR do?
- Ensures that a user verify their account before login
- Ensures that a token is blacklisted appropriately after logout
#### Description of Task to be completed?
- add function to ensure a user has verified their account before login
- fix logic flow at token verification to check for tokens in the Redis blacklist
#### How should this be manually tested?
- git clone this repo and checkout to `bg-verify-b4-login-blacklist-token-168050005` branch
- run the application and try to log in a user who has not verified their account
- verify their account and log them in
- use the token generated at login to log them out
- try to log out the user again with the same token
#### Any background context you want to provide?
this is a bug fix
#### What are the relevant pivotal tracker stories?
[#168505153](https://www.pivotaltracker.com/story/show/168505153)
#### What are the relevant Github Issues?
N/A
#### Screenshots (if appropriate)
###### login before account verification
![image](https://user-images.githubusercontent.com/45405036/64951619-93e13680-d87e-11e9-8247-71f305f57640.png)

###### Using a blacklisted token
![image](https://user-images.githubusercontent.com/45405036/64951543-6bf1d300-d87e-11e9-9e92-3daf5fddb461.png)


#### Questions:
N/A