### PR TITLE
#168050028 Users should be able to like/unlike an accommodation facility

### DIFF
--- a/src/database/migrations/20191001053857-create-likes.js
+++ b/src/database/migrations/20191001053857-create-likes.js
@@ -1,0 +1,46 @@
+/* eslint-disable no-unused-vars */
+/**
+ *
+ * @param {*} queryInterface
+ * @param {*} Sequelize
+ * @returns {*} likes table
+ */
+export function up(queryInterface, Sequelize) {
+  return queryInterface.createTable('Likes', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    user_id: {
+      type: Sequelize.INTEGER,
+      allowNull: false
+    },
+    accommodation_id: {
+      type: Sequelize.INTEGER,
+      allowNull: false
+    },
+    status: {
+      type: Sequelize.BOOLEAN,
+      allowNull: false
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  });
+}
+/**
+ *
+ * @param {*} queryInterface
+ * @param {*} Sequelize
+ * @returns {*} deletes Likes table
+ */
+export function down(queryInterface, Sequelize) {
+  return queryInterface.dropTable('Likes');
+}

--- a/src/database/models/accomodations.js
+++ b/src/database/models/accomodations.js
@@ -17,6 +17,9 @@ export default (sequelize, DataTypes) => {
     Accomodations.hasMany(models.Room, {
       foreignKey: 'accommodation_id',
     });
+    Accomodations.hasMany(models.Likes, {
+      foreignKey: 'accommodation_id',
+    });
     Accomodations.belongsTo(models.User, {
       onDelete: 'CASCADE',
       foreignKey: 'owner',

--- a/src/database/models/likes.js
+++ b/src/database/models/likes.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-unused-vars */
+export default (sequelize, DataTypes) => {
+  const Likes = sequelize.define('Likes', {
+    user_id: DataTypes.INTEGER,
+    accommodation_id: DataTypes.INTEGER,
+    status: DataTypes.BOOLEAN
+  }, {});
+  Likes.associate = (models) => {
+    // associations can be defined here
+    Likes.belongsTo(models.User, {
+      onDelete: 'CASCADE',
+      foreignKey: 'user_id',
+    });
+    Likes.belongsTo(models.Accomodations, {
+      onDelete: 'CASCADE',
+      foreignKey: 'accommodation_id',
+    });
+  };
+  return Likes;
+};

--- a/src/database/models/user.js
+++ b/src/database/models/user.js
@@ -34,6 +34,9 @@ export default (sequelize, DataTypes) => {
     User.hasMany(models.Accomodations, {
       foreignKey: 'owner',
     });
+    User.hasMany(models.Likes, {
+      foreignKey: 'user_id',
+    });
   };
   return User;
 };

--- a/src/database/seeders/20191001085625-accommodations.js
+++ b/src/database/seeders/20191001085625-accommodations.js
@@ -1,0 +1,48 @@
+/* eslint-disable no-unused-vars */
+/**
+ * @func up
+ * @param {*} queryInterface
+ * @param {*} Sequelize
+ * @return {func} bulkInsert
+ */
+export function up(queryInterface, Sequelize) {
+  return queryInterface.bulkInsert('Accomodations', [{
+    accommodation_name: 'Kigali Marriott Hotel',
+    location: 1,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  },
+  {
+    accommodation_name: 'Kigali Serena Hotel',
+    location: 1,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  },
+  {
+    accommodation_name: 'Kigali Radisson Blu Hotel',
+    location: 1,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  },
+  {
+    accommodation_name: 'Four Seasons Hotel',
+    location: 2,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  },
+  {
+    accommodation_name: 'EKO Hotels & Suites',
+    location: 3,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }], {});
+}
+/**
+ * @func down
+ * @param {*} queryInterface
+ * @param {*} Sequelize
+ * @returns {func} bulkDelete
+ */
+export function down(queryInterface, Sequelize) {
+  return queryInterface.bulkDelete('Accomodations', null, {});
+}

--- a/src/routes/AccomodationsRoutes.js
+++ b/src/routes/AccomodationsRoutes.js
@@ -17,10 +17,11 @@ const {
   viewSingleAccommodation,
   viewAllRoomsByAccommodation,
   viewAllAccommodations,
-  viewAllAccommodationsByLocation
+  viewAllAccommodationsByLocation,
+  likeAccommodation
 } = AccomodationController;
 const {
-  validateHostAccommodations, validateAccommodations, validateRooms, validateNewRoom
+  validateHostAccommodations, validateAccommodations, validateRooms, validateNewRoom, validateLike
 } = Validation;
 
 router.post('/', verifyToken, multipartyMiddle, accommodationData, validator, createAccomodation);
@@ -31,5 +32,5 @@ router.get('/location/:id', viewAllAccommodationsByLocation);
 router.get('/:id', viewSingleAccommodation);
 router.get('/:id/rooms', viewAllRoomsByAccommodation);
 router.get('/:accomodationid/rooms/:id', viewSingleRoom);
-
+router.post('/:id/like', verifyToken, validateLike, likeAccommodation);
 export default router;

--- a/src/services/AccomodationServices.js
+++ b/src/services/AccomodationServices.js
@@ -1,6 +1,5 @@
 /* eslint-disable camelcase */
 import database from '../database/models';
-
 /**
  * @class AccomodationServices
  */

--- a/src/services/LikeServices.js
+++ b/src/services/LikeServices.js
@@ -1,0 +1,55 @@
+import database from '../database/models';
+/**
+ * @class LikeService
+ */
+class LikeService {
+  /**
+     *
+     * @param {*} like
+     * @returns {*} like
+     */
+  static async addLike(like) {
+    const newLike = await database.Likes.create(like);
+    return newLike;
+  }
+
+  /**
+ *
+ * @param {*} accommodationId
+ * @param {*} userId
+ * @param {*} status
+ * @returns {*} removed like
+ */
+  static async updateLike(accommodationId, userId, status) {
+    await database.Likes.update(status, {
+      where:
+        { accommodation_id: accommodationId, user_id: userId }
+    });
+    return status;
+  }
+
+  /**
+   *
+   * @param {*} accommodationId
+   * @returns {*} amount of likes
+   */
+  static async countLikes(accommodationId) {
+    const likes = database.Likes.count({ where: { accommodation_id: accommodationId, status: 'true' } });
+    return likes;
+  }
+
+  /**
+   *
+   * @param {*} accommodationId
+   * @param {*} userId
+   * @returns {*} like
+   */
+  static async findLike(accommodationId, userId) {
+    const like = await database.Likes.findOne({
+      where: { accommodation_id: accommodationId, user_id: userId }
+    });
+    if (!like) return null;
+    return like.dataValues;
+  }
+}
+export default LikeService;

--- a/src/validation/Validations.js
+++ b/src/validation/Validations.js
@@ -312,4 +312,17 @@ export default class Validation {
     }
     next();
   }
+  static async validateLike(req, res, next) {
+    if (isNaN(req.params.id)) {
+      util.setError(400, 'Accommodation id must be a valid Integer');
+      return util.send(res);
+    }
+    // accommodation exist
+    const accommodation = await findAccommodationById(req.params.id);
+    if (!accommodation) {
+      util.setError(404, 'Accommodation does not exist');
+      return util.send(res);
+    }
+    next();
+  }
 }

--- a/swagger.json
+++ b/swagger.json
@@ -307,7 +307,7 @@
         }
       }
     },
-    "/2": {
+    "/{user_id}": {
       "get": {
         "description": "TODO: Add Description",
         "summary": "Get Single Profile",
@@ -319,7 +319,18 @@
         "produces": [
           "application/json"
         ],
-
+        "parameters": [
+          {
+            "name" : "user_id",
+            "in" : "path",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
@@ -349,7 +360,7 @@
         }
       }
     },
-    "/company/Andela": {
+    "/company/{company_name}": {
       "get": {
         "description": "TODO: Add Description",
         "summary": "Get by company",
@@ -361,7 +372,18 @@
         "produces": [
           "application/json"
         ],
-
+        "parameters": [
+          {
+            "name" : "company_name",
+            "in" : "path",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
@@ -617,7 +639,7 @@
         "description": "add an accomodation facility",
         "summary": "Accomodation  facility",
         "tags": [
-          "Accomodations"
+          "Accommodations"
         ],
         "operationId": "AccommodationsPost",
         "deprecated": false,
@@ -677,6 +699,315 @@
             "required": true,
             "type": "string",
             "description": ""
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "headers": {}
+          }
+        }
+      }
+    },
+    "/accommodations/hosts": {
+      "post": {
+        "description": "Host adds accommodation",
+        "summary": "Host Add accomodation",
+        "tags": [
+          "Accommodations"
+        ],
+        "operationId": "AccommodationsHostsPost",
+        "deprecated": false,
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "default": "Bearer {token}",
+            "type": "string"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "name": "images",
+            "in": "formData",
+            "required": true,
+            "type": "file",
+            "description": ""
+          },
+          {
+            "name": "accommodation_name",
+            "in": "formData",
+            "required": true,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "name": "description",
+            "in": "formData",
+            "required": true,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "name": "location",
+            "in": "formData",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "description": ""
+          },
+          {
+            "name": "services",
+            "in": "formData",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": ""
+          },
+          {
+            "name": "amenities",
+            "in": "formData",
+            "required": true,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": ""
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "headers": {}
+          }
+        }
+      }
+    },
+    "/accommodations/rooms": {
+      "post": {
+        "description": "Add a room to accommodation",
+        "summary": "Add room to accommodation",
+        "tags": [
+          "Accommodations"
+        ],
+        "operationId": "AccommodationsRoomsPost",
+        "deprecated": false,
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "default": "Bearer {token}",
+            "type": "string"
+          },
+          {
+            "name": "accommodation_id",
+            "in": "formData",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "description": ""
+          },
+          {
+            "name": "name",
+            "in": "formData",
+            "required": true,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "name": "room_type",
+            "in": "formData",
+            "required": true,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "name": "description",
+            "in": "formData",
+            "required": true,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "name": "cost",
+            "in": "formData",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "description": ""
+          },
+          {
+            "name": "status",
+            "in": "formData",
+            "required": true,
+            "type": "boolean",
+            "description": ""
+          },
+          {
+            "name": "images",
+            "in": "formData",
+            "required": true,
+            "type": "file",
+            "description": ""
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "headers": {}
+          }
+        }
+      }
+    },
+    "/accommodations/{accommodation_id}": {
+      "get": {
+        "description": "Get specific accommodation",
+        "summary": "Get specific Accommodation",
+        "tags": [
+          "Accommodations"
+        ],
+        "operationId": "Accommodations1Rooms1Get",
+        "deprecated": false,
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name" : "accommodation_id",
+            "in" : "path",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "headers": {}
+          }
+        }
+      }
+    },
+    "/accommodations/{accommodation_id}/rooms": {
+      "get": {
+        "description": "Get all rooms in an accommocation",
+        "summary": "Get all rooms in an Accommodations",
+        "tags": [
+          "Accommodations"
+        ],
+        "operationId": "Accommodations1Rooms1Get2",
+        "deprecated": false,
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name" : "accommodation_id",
+            "in" : "path",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "headers": {}
+          }
+        }
+      }
+    },
+    "/accommodations/{accommodation_id}/rooms/{room_id}": {
+      "get": {
+        "description": "Get a specifc room inside an accommodation",
+        "summary": "Get a specific room inside an Accommodations",
+        "tags": [
+          "Accommodations"
+        ],
+        "operationId": "Accommodations1Rooms1Get",
+        "deprecated": false,
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name" : "accommodation_id",
+            "in" : "path",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "integer"
+            }
+          },
+          {
+            "name" : "room_id",
+            "in" : "path",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "headers": {}
+          }
+        }
+      }
+    },
+    "/accommodations/{accommodation_id}/like": {
+      "post": {
+        "description": "Like and Unlike an accommodation",
+        "summary": "Like/Unlike",
+        "tags": [
+          "Accommodations"
+        ],
+        "operationId": "Accommodations2LikePost",
+        "deprecated": false,
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name" : "accommodation_id",
+            "in" : "path",
+            "required" : true,
+            "style" : "simple",
+            "explode" : false,
+            "schema" : {
+              "type" : "integer"
+            }
           }
         ],
         "responses": {
@@ -811,6 +1142,133 @@
             "headers": {}
           },
           "403": {
+            "description": "",
+            "headers": {}
+          }
+        }
+      }
+    },
+    "/hosts": {
+      "post": {
+        "description": "Adding a host",
+        "summary": "Add host",
+        "tags": [
+          "HOST"
+        ],
+        "operationId": "HostsPost",
+        "deprecated": false,
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "default": "Bearer {token}",
+            "type": "string"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "name": "email",
+            "in": "formData",
+            "required": true,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "name": "firstname",
+            "in": "formData",
+            "required": true,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "name": "lastname",
+            "in": "formData",
+            "required": true,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "headers": {}
+          }
+        }
+      }
+    },
+    "/hosts/reset": {
+      "patch": {
+        "description": "TODO: Add Description",
+        "summary": "reset password host",
+        "tags": [
+          "HOST"
+        ],
+        "operationId": "HostsResetPatch",
+        "deprecated": false,
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/x-www-form-urlencoded"
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "default": "Bearer {token}",
+            "type": "string"
+          },
+          {
+            "name": "Content-Type",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "name": "email",
+            "in": "formData",
+            "required": true,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "name": "password",
+            "in": "formData",
+            "required": true,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "name": "confirm_password",
+            "in": "formData",
+            "required": true,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "name": "old_password",
+            "in": "formData",
+            "required": true,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "responses": {
+          "200": {
             "description": "",
             "headers": {}
           }


### PR DESCRIPTION
#### What does this PR do?
This feature allows user to like and unlike an accommodation
#### Description of Task to be completed?

- Create Vote

- Update the vote second time

- Count votes and list them besides accommodation information

#### How should this be manually tested?
1. Start by cloning repository
`git clone https://github.com/andela/technites-bn-backend.git`

2. Then checkout to this branch
`git checkout ft-User-can-like-accommodation-#168050028`

3. Run `npm run install`

4. Run `npm run migrate`

5. Run `npm run seed` this will add two locations with id `1` and `2` and also a user with email `requester@request.com`, the password here is the one you have in your `.env` file for `SUPER_ADMIN` you will need this in testing.

6. Start server  `npm run  dev`

7. Now login with that user `requester@request.com` there are various accommodations created with the seeders with id's ranging from `1-5`.

8. To like an accommodation head to the route `api/v1/accommodations/:<accommodationId>/like` with `POST` method, use the accommodation id that was seeded and your like will be recorded, if you do it the second time it will the unlike the accommodation.

9. To test it head to `api/v1/accommodations/:<accommodationId>`, `GET` method and you will notice the changes in likes field.

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#168050028](https://www.pivotaltracker.com/story/show/168050028)
#### What are the relevant Github Issues?
N/A
#### Screenshots (if appropriate)
<img width="1118" alt="Screen Shot 2019-10-01 at 15 18 06" src="https://user-images.githubusercontent.com/42216593/65965400-e154ca80-e45e-11e9-8fc5-0d6f8458318f.png">
<img width="1128" alt="Screen Shot 2019-10-01 at 15 19 05" src="https://user-images.githubusercontent.com/42216593/65965402-e1ed6100-e45e-11e9-94cd-65bbb5b93adc.png">

#### Questions:
N/A