### PR TITLE
#168945764 user can enable or disable email notifications

### DIFF
--- a/src/controllers/AccomodationController.js
+++ b/src/controllers/AccomodationController.js
@@ -22,7 +22,9 @@ const {
   findAccommodationFeedback
 } = AccomodationServices;
 const { addRoom, findRoomById, getAllRoomsByAccommodation } = RoomServices;
-const { addLike, updateLike, findLike, countLikes } = LikeServices;
+const {
+ addLike, updateLike, findLike, countLikes 
+} = LikeServices;
 const util = new Util();
 /**
  * @class AccomodationControler
@@ -169,13 +171,8 @@ class AccomodationControler {
  * @returns {*} user
  */
   static async viewSingleAccommodation(req, res) {
-    let singleAccommodation;
-    singleAccommodation = await findAccommodationFeedback(req.params.id);
-    if (singleAccommodation) {
-      util.setSuccess(200, 'Accommodation found!', singleAccommodation);
-      return util.send(res);
-    }
-    singleAccommodation = await findAccommodationById(req.params.id);
+  // let singleAccommodation;
+    const singleAccommodation = await findAccommodationFeedback(req.params.id);
     if (!singleAccommodation) {
       util.setError(404, 'Accommodation not found');
       return util.send(res);

--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -28,7 +28,8 @@ const {
   updateProfile,
   findUserById,
   displayAllUsers,
-  findUserByCompany
+  findUserByCompany,
+  updateEmailNotification
 } = UserService;
 let msgType = null;
 const { CLOUDINARY_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET } = process.env;
@@ -289,6 +290,19 @@ class UserController {
     }
     util.setSuccess(200, 'All users!', allUsers);
     return util.send(res);
+  }
+
+  /**
+ *
+ * @param {*} req
+ * @param {*} res
+ * @returns {*} all users
+ */
+  static async enableOrDisableEmailNotifications(req, res) {
+    await updateEmailNotification(req.user.email, req.query.emailAllowed);
+    if (req.query.emailAllowed === 'true') return res.status(200).json({ status: res.statusCode, message: 'You subscribed to email notifications' });
+
+    return res.status(200).json({ status: res.statusCode, message: 'You unsubscribed to email notifications' });
   }
 }
 

--- a/src/routes/UserRoutes.js
+++ b/src/routes/UserRoutes.js
@@ -14,7 +14,8 @@ const connection = connect();
 
 const { verifyToken } = UserAuthentication;
 const {
-  editProfile, viewSingleProfile, viewAllProfiles, viewProfilesByCompany
+  editProfile, viewSingleProfile, viewAllProfiles,
+  viewProfilesByCompany, enableOrDisableEmailNotifications,
 } = UserController;
 
 const { getRequests } = RequestController;
@@ -29,6 +30,7 @@ router.patch('/editprofile', verifyToken, connection, updateProfileValidator, ed
 router.get('/user/:id', viewSingleProfile);
 router.get('/users/all', viewAllProfiles);
 router.get('/users/company/:company', viewProfilesByCompany);
+router.post('/users/notifications', [verifyToken], enableOrDisableEmailNotifications);
 
 // get requests
 router.get('/users/:id/requests', verifyToken, getRequests);

--- a/src/services/RequestServices.js
+++ b/src/services/RequestServices.js
@@ -172,6 +172,23 @@ class RequestService {
   }
 
   /**
+*
+* @param {Array} destinationsIds
+* @returns {Boolean} true or false
+*/
+  static async findIfLocationsExists(destinationsIds) {
+    const nonExistentIds = [];
+    for (let i = 0; i < destinationsIds.length; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      const origin = await database.location.findOne({
+        where: { id: destinationsIds[i] }
+      });
+      if (origin === null) nonExistentIds.push(destinationsIds[i]);
+    }
+    return nonExistentIds;
+  }
+
+  /**
  *
  * @param {*} id
  * @param {*} request

--- a/src/services/UserServices.js
+++ b/src/services/UserServices.js
@@ -219,6 +219,15 @@ class UserService {
     });
     return checkService(users);
   }
+
+  /**
+   * @param {String} userEmail
+   * @param {String} option
+   * @returns {Integer} userId
+   */
+  static async updateEmailNotification(userEmail, option) {
+    return database.User.update({ isEmailAllowed: option }, { where: { email: userEmail } });
+  }
 }
 
 export default UserService;

--- a/src/validation/Validations.js
+++ b/src/validation/Validations.js
@@ -97,6 +97,7 @@ export default class Validation {
       company: Joi.string().min(2).max(30),
       department: Joi.string().min(2).max(30),
       line_manager: Joi.string(),
+      isEmailAllowed: Joi.boolean(),
     });
     genericValidator(req, res, schema, next);
   }
@@ -250,7 +251,7 @@ export default class Validation {
       name: Joi.string().min(2).max(30).required(),
       room_type: Joi.string().regex(/^(single|double|triple|quad|queen|king|twin|studio)$/).required(),
       description: Joi.string().required(),
-      cost: Joi.number().integer().required(),
+      cost: Joi.number().integer().min(1).required(),
       status: Joi.boolean().required()
     });
     genericValidator(req, res, schema, next);

--- a/test/User.spec.js
+++ b/test/User.spec.js
@@ -232,6 +232,31 @@ describe('users endpoints', () => {
         });
     });
   });
+  describe('POST: /api/v1/users/notifications enable or disable', () => {
+    it('Should disable the email notifications', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/users/notifications?emailAllowed=false')
+        .set('Authorization', `${token}`)
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.message).to.be.a('string');
+          done();
+        });
+    });
+
+    it('Should disable the email notifications', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/users/notifications?emailAllowed=true')
+        .set('Authorization', `${token}`)
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.message).to.be.a('string');
+          done();
+        });
+    });
+  });
 
   describe('POST api/v1/auth/login/:token', () => {
     let confirmationToken = jwt.sign(dummyUser, process.env.JWT_SECRET, { expiresIn: '24h' });


### PR DESCRIPTION
#### What does this PR do?
This PR fixes: 
 - a problem to enable or disable email notifications
 - a problem of making a request without a valid line manager
 - a problem of making a request without a valid destination id
#### Description of Task to be completed?

- Give a user the ability to enable or disable email notifications
- Avoid that a user can make a request without a valid line manager
- Avoid that a user can make a request without a valid destination id

#### How should this be manually tested?
1. Start by cloning repository
`git clone https://github.com/andela/technites-bn-backend.git`

2. Then checkout to this branch
`git checkout bg-fix-email-options-functionality-168945764`

3. Run `npm i`

4. a) Run `npm run migrate:refresh`
    b) Run `npm run seed`

5. Start server  `npm run  dev`

7. Now create an account on this endpoint using POST : `/api/v1/auth/register/`

8. Now login on this endpoint using POST : `/api/v1/auth/login/`

9. Now subscribe to email notifications on this endpoint using POST : `/api/v1/users/notifications?emailAllowed=true`

10. 9. Now unsubscribe to email notifications on this endpoint using POST : `/api/v1/users/notifications?emailAllowed=false`

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#168945764](https://www.pivotaltracker.com/story/show/168945764)
#### What are the relevant Github Issues?
N/A
#### Screenshots (if appropriate)
*email notification*
<img width="974" alt="Screen Shot 2019-10-04 at 11 42 10" src="https://user-images.githubusercontent.com/33954234/66198125-07b37980-e69c-11e9-8d01-392f69291ee0.png">


#### Questions:
N/A
