### PR TITLE
#168050018 Users should be able to mark all notifications as read

### DIFF
--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -34,7 +34,8 @@ const {
   findUserById,
   displayAllUsers,
   findUserByCompany,
-  updateEmailNotification
+  updateEmailNotification,
+  updateNotificationsAsSeen
 } = UserService;
 let msgType = null;
 const { CLOUDINARY_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET } = process.env;
@@ -347,6 +348,18 @@ class UserController {
     } catch (e) {
       next(e);
     }
+  }
+
+  /**
+ *
+ * @param {*} req
+ * @param {*} res
+ * @returns {*} all users
+ */
+  static async markNotificationsAsSeen(req, res) {
+    await updateNotificationsAsSeen(req.user.id);
+
+    return res.status(200).json({ status: res.statusCode, message: 'All notifications are marked as read' });
   }
 }
 

--- a/src/database/migrations/20191001164659-create-notification.js
+++ b/src/database/migrations/20191001164659-create-notification.js
@@ -19,6 +19,11 @@ export function up(queryInterface, Sequelize) {
       type: Sequelize.STRING,
       allowNull: false
     },
+    seen: {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: false
+    },
     createdAt: {
       allowNull: false,
       type: Sequelize.DATE

--- a/src/database/models/notification.js
+++ b/src/database/models/notification.js
@@ -25,6 +25,11 @@ export default (sequelize, DataTypes) => {
         type: DataTypes.STRING,
         allowNull: false
       },
+      seen: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        defaultValue: false,
+      },
       createdAt: {
         allowNull: false,
         type: DataTypes.DATE

--- a/src/routes/UserRoutes.js
+++ b/src/routes/UserRoutes.js
@@ -13,7 +13,8 @@ const connection = connect();
 const { verifyToken } = UserAuthentication;
 const {
   editProfile, viewSingleProfile, viewAllProfiles,
-  viewProfilesByCompany, enableOrDisableEmailNotifications, getUserTrips
+  viewProfilesByCompany, enableOrDisableEmailNotifications, getUserTrips,
+  markNotificationsAsSeen
 } = UserController;
 
 const { getRequests } = RequestController;
@@ -26,6 +27,7 @@ router.post('/notifications', [verifyToken], enableOrDisableEmailNotifications);
 router.get('/:id', viewSingleProfile);
 router.get('/', viewAllProfiles);
 router.get('/company/:company', viewProfilesByCompany);
+router.patch('/notifications/seen', [verifyToken], markNotificationsAsSeen);
 
 // get requests
 router.get('/:id/requests', verifyToken, getRequests);

--- a/src/services/UserServices.js
+++ b/src/services/UserServices.js
@@ -228,6 +228,14 @@ class UserService {
   static async updateEmailNotification(userEmail, option) {
     return database.User.update({ isEmailAllowed: option }, { where: { email: userEmail } });
   }
+
+  /**
+   * @param {Integer} userId;
+   * @returns {Object} updated field
+   */
+  static async updateNotificationsAsSeen(userId) {
+    return database.Notification.update({ seen: true }, { where: { user_id: userId } });
+  }
 }
 
 export default UserService;

--- a/test/User.spec.js
+++ b/test/User.spec.js
@@ -234,7 +234,7 @@ describe('users endpoints', () => {
         });
     });
   });
-  describe('POST: /api/v1/users/notifications enable or disable', () => {
+  describe('POST: /api/v1/users/notifications', () => {
     it('Should disable the email notifications', (done) => {
       chai
         .request(app)
@@ -251,6 +251,18 @@ describe('users endpoints', () => {
       chai
         .request(app)
         .post('/api/v1/users/notifications?emailAllowed=true')
+        .set('Authorization', `${token}`)
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.message).to.be.a('string');
+          done();
+        });
+    });
+
+    it('Should mark all notifications as read', (done) => {
+      chai
+        .request(app)
+        .patch('/api/v1/users/notifications/seen')
         .set('Authorization', `${token}`)
         .end((err, res) => {
           expect(res.status).to.equal(200);


### PR DESCRIPTION
#### What does this PR do?
This feature allows the user to mark all the notifications as read
#### Description of Task to be completed?

- Create a request
- Make all the notifications of a particular user as read

#### How should this be manually tested?
1. Start by cloning repository
`git clone https://github.com/andela/technites-bn-backend.git`

2. Then checkout to this branch
`git checkout ft-mark-notifications-as-read-168050018`

3. Run `npm run migrate:refresh`

4. Run `npm run seed`

5. Start server  `npm run  dev`

6. Now you can create a request on this endpoint using POST: `/api/v1/requests/`

7. Now you can login a travel manager on this endpoint using POST: `/api/v1/auth/login/`
    the email is : `technitesdev@gmail.com`,
    the password is : `you can use the password you have in your .env file`

8. Now you can mark all notifications of travel manager as read on this endpoint by using PATCH: `/api/v1/users/notifications/seen`

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#168050018](https://www.pivotaltracker.com/story/show/168050018)
#### What are the relevant Github Issues?
N/A
#### Screenshots (if appropriate)
*Mark all notifications as read*
<img width="1015" alt="Screen Shot 2019-10-07 at 13 05 10" src="https://user-images.githubusercontent.com/33954234/66306903-2ff0e180-e903-11e9-928a-9b227cf810ac.png">

#### Questions:
N/A