### PR TITLE
#168050014 Profile Information from Travel Request Page

### DIFF
--- a/src/controllers/RequestController.js
+++ b/src/controllers/RequestController.js
@@ -48,7 +48,7 @@ const {
 } = RequestServices;
 const { changeRoomStatus, bookRoom, releaseBooking } = RoomService;
 const { updateAccommodations, findAllAccommodationsByLocation } = AccommodationService;
-const { findUserById } = UserService;
+const { findUserById, autoFill } = UserService;
 const { requestEmailTheme, userConfirmTheme, sendEmail } = MailHelper;
 const { searchRequestUtil } = SearchUtils;
 const util = new Utils();
@@ -101,7 +101,7 @@ class RequestController {
       RequestController.sendUserEmail('You sent new trip request', 'Trip request confirmation sent', 'was succesfully received', req.user, request);
     }
     if (response) {
-      util.setSuccess(201, 'Sent request. Please wait travel admin to approve it', dbRequest); 
+      util.setSuccess(201, 'Sent request. Please wait travel admin to approve it', dbRequest);
       return util.send(res);
     }
     util.setError(500, 'Failed to send request email try again later!');
@@ -109,10 +109,26 @@ class RequestController {
   }
 
   /**
-   * @param {Object} req
-   * @param {Object} res
-   * @returns {Object} updated request
-   */
+     *
+     * @param {*} req
+     * @param {*} res
+     * @param {*} next
+     * @returns {Object} newUser
+     */
+  static async setAutoFill(req, res, next) {
+    if (req.params.autofill === 'true' || req.params.autofill === 'false') {
+      await autoFill(req.params.autofill, req.user.email);
+      res.status(200).json({ status: res.statusCode, message: 'updated successfully' });
+    } else {
+      res.status(400).json({ status: res.statusCode, error: 'Use only true or false for enabling auto-fill option' });
+    }
+  }
+
+  /**
+ * @param {Object} req
+ * @param {Object} res
+ * @returns {Object} updated request
+ */
   static async updateRequest(req, res) {
     const request = req.body;
     const { user } = req;
@@ -368,7 +384,7 @@ class RequestController {
     }
     return res.status(200).json({
       status: res.statusCode,
-      message: 'No requests found!'
+      error: 'No requests found!'
     });
   }
 

--- a/src/database/migrations/20190904073354-create-user.js
+++ b/src/database/migrations/20190904073354-create-user.js
@@ -7,6 +7,10 @@ export function up(queryInterface, Sequelize) {
       primaryKey: true,
       type: Sequelize.INTEGER
     },
+    auto_fill: {
+      type: Sequelize.BOOLEAN,
+      defaultValue: false
+    },
     firstname: {
       type: Sequelize.STRING,
       allowNull: false

--- a/src/database/migrations/20190917120002-create-request.js
+++ b/src/database/migrations/20190917120002-create-request.js
@@ -17,6 +17,14 @@ export function up(queryInterface, Sequelize) {
         as: 'user_id',
       },
     },
+    passport_name: {
+      type: Sequelize.STRING,
+      allowNull: true
+    },
+    passport_number: {
+      type: Sequelize.INTEGER,
+      allowNull: true
+    },
     request_type: {
       type: Sequelize.STRING,
       allowNull: false

--- a/src/database/models/request.js
+++ b/src/database/models/request.js
@@ -21,6 +21,14 @@ export default (sequelize, DataTypes) => {
         isDate: true
       }
     },
+    passport_name: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    passport_number: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
     return_date: DataTypes.STRING,
     destinations: {
       type: DataTypes.JSONB,

--- a/src/database/models/user.js
+++ b/src/database/models/user.js
@@ -23,6 +23,10 @@ export default (sequelize, DataTypes) => {
       allowNull: false,
       defaultValue: true,
     },
+    auto_fill: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
   }, {});
   // eslint-disable-next-line no-unused-vars
   User.associate = (models) => {

--- a/src/database/seeders/20190910075430-test-user.js
+++ b/src/database/seeders/20190910075430-test-user.js
@@ -6,7 +6,7 @@ import bcrypt from 'bcrypt';
 const { SUPER_ADMIN_PASS } = process.env;
 const password = bcrypt.hashSync(SUPER_ADMIN_PASS, 8);
 export function up(queryInterface, Sequelize) {
-   return queryInterface.bulkInsert('Users', [{
+  return queryInterface.bulkInsert('Users', [{
     firstname: 'John',
     lastname: 'Doe',
     username: 'johndoe',
@@ -14,6 +14,7 @@ export function up(queryInterface, Sequelize) {
     password,
     company: 'Andela',
     is_verified: true,
+    auto_fill: true,
     role_value: 7,
     line_manager: 'technitesdev@gmail.com',
     createdAt: new Date(),
@@ -26,6 +27,7 @@ export function up(queryInterface, Sequelize) {
     email: 'technitesdev2@gmail.com',
     password,
     is_verified: false,
+    auto_fill: false,
     line_manager: 'technitesdev@gmail.com',
     createdAt: new Date(),
     updatedAt: new Date()
@@ -37,6 +39,7 @@ export function up(queryInterface, Sequelize) {
     email: 'technitesdev@gmail.com',
     password, // currently in .env
     is_verified: true,
+    auto_fill: false,
     line_manager: 'technitesdev@gmail.com',
     role_value: 7,
     createdAt: new Date(),
@@ -49,6 +52,7 @@ export function up(queryInterface, Sequelize) {
     email: 'travel@admin.com',
     password,
     is_verified: true,
+    auto_fill: false,
     line_manager: 'technitesdev@gmail.com',
     role_value: 4,
     createdAt: new Date(),
@@ -61,6 +65,7 @@ export function up(queryInterface, Sequelize) {
     email: 'requester@request.com',
     password,
     is_verified: true,
+    auto_fill: true,
     line_manager: 'manager@admin.com',
     role_value: 1,
     createdAt: new Date(),
@@ -73,6 +78,7 @@ export function up(queryInterface, Sequelize) {
     email: 'manager@admin.com',
     password,
     is_verified: true,
+    auto_fill: false,
     role_value: 2,
     line_manager: 'manager@admin.com',
     createdAt: new Date(),
@@ -87,6 +93,7 @@ export function up(queryInterface, Sequelize) {
     company: 'NewCompany',
     line_manager: 'manager@admin.com',
     is_verified: true,
+    auto_fill: false,
     role_value: 1,
     createdAt: new Date(),
     updatedAt: new Date()
@@ -98,6 +105,7 @@ export function up(queryInterface, Sequelize) {
     email: 'nolinemanager@gmail.com',
     password,
     company: 'NewCompany',
+    auto_fill: false,
     is_verified: true,
     role_value: 1,
     createdAt: new Date(),
@@ -110,14 +118,15 @@ export function up(queryInterface, Sequelize) {
     email: 'host5@gmail.com',
     password,
     company: 'NewCompany',
+    auto_fill: false,
     is_verified: true,
     role_value: 0,
     createdAt: new Date(),
     updatedAt: new Date()
   }
-], {});
+  ], {});
 }
 
 export function down(queryInterface, Sequelize) {
-      return queryInterface.bulkDelete('Users', null, {});
+  return queryInterface.bulkDelete('Users', null, {});
 }

--- a/src/database/seeders/20190918093500-request.js
+++ b/src/database/seeders/20190918093500-request.js
@@ -7,6 +7,8 @@ export function up(queryInterface, Sequelize) {
     location_id: 1,
     departure_date: moment().toDate(),
     return_date: moment().add(7, 'days').toDate(),
+    passport_name: 'my name',
+    passport_number: '1234567890',
     destinations: [
       {
         destination_id: 2,
@@ -26,6 +28,8 @@ export function up(queryInterface, Sequelize) {
     location_id: 1,
     departure_date: moment().toDate(),
     return_date: moment().add(7, 'days').toDate(),
+    passport_name: 'my name',
+    passport_number: '1234567890',
     destinations: [
       {
         destination_id: 3,
@@ -45,6 +49,8 @@ export function up(queryInterface, Sequelize) {
     location_id: 3,
     departure_date: moment().toDate(),
     return_date: moment().add(7, 'days').toDate(),
+    passport_name: 'my name',
+    passport_number: '1234567890',
     destinations: [
       {
         destination_id: 1,
@@ -64,6 +70,8 @@ export function up(queryInterface, Sequelize) {
     location_id: 3,
     departure_date: moment().toDate(),
     return_date: moment().add(7, 'days').toDate(),
+    passport_name: 'my name',
+    passport_number: '1234567890',
     destinations: [
       {
         destination_id: 1,
@@ -80,6 +88,8 @@ export function up(queryInterface, Sequelize) {
   {
     user_id: 1,
     request_type: 'OneWay',
+    passport_name: 'my name',
+    passport_number: '1234567890',
     location_id: 1,
     departure_date: moment().toDate(),
     return_date: moment().add(7, 'days').toDate(),
@@ -99,6 +109,8 @@ export function up(queryInterface, Sequelize) {
   {
     user_id: 1,
     request_type: 'OneWay',
+    passport_name: 'my name',
+    passport_number: '1234567890',
     location_id: 1,
     departure_date: moment().toDate(),
     return_date: moment().add(7, 'days').toDate(),
@@ -118,6 +130,8 @@ export function up(queryInterface, Sequelize) {
   {
     user_id: 5,
     request_type: 'OneWay',
+    passport_name: 'my name',
+    passport_number: '1234567890',
     location_id: 1,
     departure_date: '2018-10-07 09:10:31.981 +00:00',
     return_date: moment().add(7, 'days').toDate(),
@@ -138,6 +152,8 @@ export function up(queryInterface, Sequelize) {
     user_id: 8,
     request_type: 'OneWay',
     location_id: 1,
+    passport_name: 'my name',
+    passport_number: '1234567890',
     departure_date: '2018-10-07 09:10:31.981 +00:00',
     return_date: moment().add(7, 'days').toDate(),
     destinations: [

--- a/src/middlewares/RequestValidation.js
+++ b/src/middlewares/RequestValidation.js
@@ -15,5 +15,9 @@ export default (req, res, next) => {
   const { error } = validateRequest(req);
   if (error) return res.status(400).json({ status: '400', error: error.details[0].message });
 
+  if (req.body.passport_name === undefined || req.body.passport_number === undefined) {
+    return res.status('404').json({ status: res.statusCode, error: 'Please add your passport name and passport number' });
+  }
+
   next();
 };

--- a/src/middlewares/checkCookies.js
+++ b/src/middlewares/checkCookies.js
@@ -1,0 +1,15 @@
+import UserServices from '../services/UserServices';
+
+const { isAutoFill, getUserLastRequest } = UserServices;
+
+export default async (req, res, next) => {
+  if (await isAutoFill(req.user.email)) {
+    const last = await getUserLastRequest(req.user.id);
+    if (last !== null) {
+      req.body.passport_name = last.dataValues.passport_name;
+      req.body.passport_number = String(last.dataValues.passport_number);
+    }
+  }
+
+  next();
+};

--- a/src/routes/RequestRoutes.js
+++ b/src/routes/RequestRoutes.js
@@ -7,6 +7,7 @@ import validate from '../middlewares/RequestValidation';
 import { queryValidation, errorCheck } from '../validation/QueryValidation';
 import CommentController from '../controllers/CommentController';
 import { commentdata, validator } from '../validation/UserValidation';
+import checkCookies from '../middlewares/checkCookies';
 
 const router = new Router();
 
@@ -26,7 +27,8 @@ const {
   getRequests,
   searchRequests,
   managerRequests,
-  mostTravelledDestinations
+  mostTravelledDestinations,
+  setAutoFill
 } = RequestController;
 
 const {
@@ -38,7 +40,9 @@ const {
 } = Validation;
 
 router.get('/', [verifyToken], mostTravelledDestinations);
-router.post('/', [verifyToken, validate], validateRequestData, validateNewRequest, createRequest);
+// router.post('/', [verifyToken, validate], validateRequestData, validateNewRequest, createRequest);
+router.post('/', [verifyToken, checkCookies, validate], validateRequestData, validateNewRequest, createRequest);
+
 router.get('/:id([0-9]{1,11})/:action(approve|reject)/:token?', reqAttachUser, validateRequestAdmin, requestAction);
 router.patch('/:id', verifyToken, updateRequestValidator, validateUpdateRequest, updateRequest);
 router.get('/manager', verifyToken, managerRequests);
@@ -61,6 +65,8 @@ router.patch(
   verifyToken,
   editRequestComment
 );
+
+router.patch('/remember/:autofill', verifyToken, setAutoFill);
 router.delete('/:request_id/comments/:comment_id', verifyToken, deleteComment);
 
 export default router;

--- a/src/services/UserServices.js
+++ b/src/services/UserServices.js
@@ -39,6 +39,33 @@ class UserService {
   }
 
   /**
+   * @param {Object} userEmail
+   * @returns {Object} true or false
+   */
+  static async isAutoFill(userEmail) {
+    const user = await database.User.findOne({ where: { email: userEmail } });
+    if (!user) return null;
+    return user.dataValues.auto_fill;
+  }
+
+  /**
+   * @param {*} autoFill
+   * @param {*} email
+   * @returns {*} object
+   */
+  static async autoFill(autoFill, email) {
+    return database.User.update({ auto_fill: autoFill }, { where: { email } });
+  }
+
+  /**
+   * @param {*} userId
+   * @returns {*} object
+   */
+  static async getUserLastRequest(userId) {
+    return database.Request.findOne({ where: { user_id: userId }, order: [['id', 'DESC']] });
+  }
+
+  /**
  *
  * @param {object} userInfo
  * @param {object} tokenOwner

--- a/src/utils/BookingCronJobs.js
+++ b/src/utils/BookingCronJobs.js
@@ -1,3 +1,5 @@
+/* eslint-disable camelcase */
+/* eslint-disable no-irregular-whitespace */
 import cron from 'node-cron';
 import { Op } from 'sequelize';
 import RoomService from '../services/RoomServices';

--- a/src/validation/Validations.js
+++ b/src/validation/Validations.js
@@ -143,6 +143,8 @@ export default class Validation {
       departure_date: Joi.date().required(),
       destinations: Joi.array().items(multiCityRequest).min(1).required(),
       reason: Joi.string().required().min(1).max(255),
+      passport_name: Joi.string(),
+      passport_number: Joi.string(),
     };
 
     if (req.body.request_type === 'ReturnTrip') {

--- a/test/Accommodations.spec.js
+++ b/test/Accommodations.spec.js
@@ -21,6 +21,7 @@ const { addUser } = UserService;
 const accomodationUrl = '/api/v1/accommodations';
 const hostToken = jwtSign({ email: 'host5@gmail.com' });
 const hostToken2 = jwtSign({ email: 'host2@gmail.com' });
+const notAllowedUser = jwtSign({ email: 'requester@request.com' });
 let accId = null;
 describe('Accomodations', () => {
   // mock cloudinary response
@@ -56,7 +57,7 @@ describe('Accomodations', () => {
         is_verified: true,
         role_value: 1,
       };
-      await addUser(requestor);      
+      await addUser(requestor);
     });
     after(async () => {
       await database.location.destroy({ where: { name: 'MyTestLocation' } });
@@ -89,6 +90,18 @@ describe('Accomodations', () => {
         .attach('images', 'src/utils/assets/accommodation2.jpg', 'accommodation2.jpg')
         .attach('images', 'src/utils/assets/accommodation3.jpeg', 'accommodation3.jpeg');
       expect(newAccommodation.body.status).to.equal(201);
+    });
+    it('Should not create an accommodation when it only has one picture', async () => {
+      const newAccommodation = await chai.request(app)
+        .post('/api/v1/accommodations/hosts')
+        .set('Authorization', `${hostToken}`)
+        .field('accommodation_name', 'Test Accommodation1')
+        .field('description', 'This is a very good place to be')
+        .field('location', locationId)
+        .field('services', '[{"service":"hello"}]')
+        .field('amenities', '[{"amenity":"hello"}]')
+        .attach('images', 'src/utils/assets/accommodation1.jpg', 'accommodation1.jpg');
+      expect(newAccommodation.body.status).to.equal(403);
     });
     it('Should not create an accommodation when user is not allowed to access it', async () => {
       const newAccommodation = await chai.request(app)
@@ -234,6 +247,19 @@ describe('Accomodations', () => {
         .attach('images', 'src/utils/assets/accommodation1.jpg', 'accommodation1.jpg')
         .attach('images', 'src/utils/assets/accommodation2.jpg', 'accommodation2.jpg')
         .attach('images', 'src/utils/assets/accommodation3.jpeg', 'accommodation3.jpeg');
+      expect(newRoom.body.status).to.equal(403);
+    });
+    it('Should not add a room to the  accommodation when it has one image', async () => {
+      const newRoom = await chai.request(app)
+        .post('/api/v1/accommodations/rooms')
+        .set('Authorization', `${hostToken2}`)
+        .field('accommodation_id', accommodation.id)
+        .field('name', 'Test Room')
+        .field('room_type', 'single')
+        .field('description', 'This is a very good place to be')
+        .field('cost', 100)
+        .field('status', true)
+        .attach('images', 'src/utils/assets/accommodation1.jpg', 'accommodation1.jpg');
       expect(newRoom.body.status).to.equal(403);
     });
     it('Should not add a room to the  accommodation when accommodation id does not exist', async () => {

--- a/test/Admin.spec.js
+++ b/test/Admin.spec.js
@@ -2,12 +2,16 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import app from '../src/index';
+import AuthHelper from '../src/utils/AuthHelper';
+
+const { jwtSign } = AuthHelper;
 
 chai.use(chaiHttp);
 chai.should();
 
 describe('users endpoints', () => {
   let adminToken;
+  const token = jwtSign({ email: 'manager@admin.com' }, '4m');
   const dummyUser = {
     firstname: 'firstname',
     lastname: 'secondname',
@@ -81,6 +85,22 @@ describe('users endpoints', () => {
         })
         .end((err, res) => {
           res.should.have.status(422);
+          done();
+        });
+    });
+
+    it('it should return 401 if a normal user tries to make another person a super admin', (done) => {
+      chai
+        .request(app)
+        .put('/api/v1/admin/users')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          new_role: 7,
+          email: dummyUser.email
+        })
+        .end((err, res) => {
+          res.should.have.status(401);
+          res.body.should.have.property('message');
           done();
         });
     });

--- a/test/Comment.spec.js
+++ b/test/Comment.spec.js
@@ -29,7 +29,9 @@ const dummyRequest = {
   {
     destination_id: 5, accomodation_id: 2, check_in: '2020-09-25', check_out: '2020-09-25', room_id: 6
   }],
-  reason: 'Medical reason'
+  reason: 'Medical reason',
+  passport_name: 'my name',
+  passport_number: '1234567890',
 };
 
 const commentOne = {

--- a/test/CronJob.spec.js
+++ b/test/CronJob.spec.js
@@ -47,13 +47,23 @@ describe('Accomodations', () => {
       departure_date: dateToUse,
       return_date: dateToUse,
       destinations: [{
-        destination_id: 4, accomodation_id: 1, dateToUse, check_out: dateToUse, room_id: roomId
+        destination_id: 4,
+        accomodation_id: 1,
+        check_in: dateToUse,
+        check_out: dateToUse,
+        room_id: roomId
       },
       {
-        destination_id: 4, accomodation_id: 1, dateToUse, check_out: dateToUse, room_id: roomId2
+        destination_id: 4,
+        accomodation_id: 1,
+        check_in: dateToUse,
+        check_out: dateToUse,
+        room_id: roomId2
       }
       ],
-      reason: 'Medical'
+      reason: 'Medical',
+      passport_name: 'my name',
+      passport_number: '1234567890',
     };
     const newRequest = await database.Request.create(request);
     requestId = newRequest.id;


### PR DESCRIPTION
#### What does this PR do?
- Ability to remember your personal information
#### Description of Task to be completed?
- Give a user the ability to provide passport name and passport number
- Give a user the ability to save his request information so that he won't be required to provide it next time
#### How should this be manually tested?
1. Start by cloning repository
`git clone https://github.com/andela/technites-bn-backend.git`

2. Then checkout to this branch
`git checkout ft-get-profile-information-168050014`

3. Run `npm install`

4. Run `npm run migrate:refresh`

5. Run `npm run seed`.

6. Start server  `npm run  dev`

7. Create a request at this endpoint `api/v1/requests?auto_fill=true` POST method

8. Send a request again without providing the passport name and passport number and the request will be saved with the previous passport information

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#168050014](https://www.pivotaltracker.com/story/show/168050014)
#### What are the relevant Github Issues?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A